### PR TITLE
T-Timers test

### DIFF
--- a/packages/blueprints/package.json
+++ b/packages/blueprints/package.json
@@ -31,7 +31,7 @@
 		"vitest": "^4.0.16"
 	},
 	"dependencies": {
-		"@sofie-automation/blueprints-integration": "26.3.0-nightly-main-20260317-140512-23b7ecc.0",
+		"@sofie-automation/blueprints-integration": "26.3.0-nightly-main-20260401-110808-7ef4508.0",
 		"dereference-json-schema": "^0.2.1",
 		"type-fest": "^4.33.0"
 	},

--- a/packages/blueprints/package.json
+++ b/packages/blueprints/package.json
@@ -31,7 +31,7 @@
 		"vitest": "^4.0.16"
 	},
 	"dependencies": {
-		"@sofie-automation/blueprints-integration": "26.3.0-nightly-main-20260401-110808-7ef4508.0",
+		"@sofie-automation/blueprints-integration": "26.3.0-nightly-main-20260421-093052-38fae25.0",
 		"dereference-json-schema": "^0.2.1",
 		"type-fest": "^4.33.0"
 	},

--- a/packages/blueprints/src/__mocks__/context.ts
+++ b/packages/blueprints/src/__mocks__/context.ts
@@ -198,6 +198,7 @@ export class RundownContext extends ShowStyleContext implements ISegmentUserCont
 	public rundown: IBlueprintRundownDB
 	public studioId = ''
 	public playlistId = ''
+	public startedPlayback: number | undefined = undefined
 	public getShowStyleSourceLayers(): Record<string, ISourceLayer | undefined> {
 		return {} // TODO: implement this
 	}

--- a/packages/blueprints/src/base/showstyle/getSegment.ts
+++ b/packages/blueprints/src/base/showstyle/getSegment.ts
@@ -12,6 +12,26 @@ import { SegmentProps } from './definitions/index.js'
 
 // Get segment is called from Core and is the main entry point for the blueprint for receiving segments
 export function getSegment(context: ISegmentUserContext, ingestSegment: SofieIngestSegment): BlueprintResultSegment {
+	// The end-of-rundown segment is injected by the studio blueprint's processIngestData.
+	// It holds only a zero-length break part used as the T-Timer anchor.
+	if (ingestSegment.externalId === 'end-of-rundown') {
+		return {
+			segment: { name: 'End of Show' },
+			parts: [
+				{
+					part: {
+						externalId: 'end-of-rundown-break',
+						title: 'Break',
+						expectedDuration: 0,
+					},
+					pieces: [],
+					adLibPieces: [],
+					actions: [],
+				},
+			],
+		}
+	}
+
 	const rundownType = (context.rundown as Readonly<IBlueprintRundown<RundownMetadata>>).privateData?.ingestType
 	let intermediateSegment: SegmentProps
 	switch (rundownType) {

--- a/packages/blueprints/src/base/showstyle/manifest.ts
+++ b/packages/blueprints/src/base/showstyle/manifest.ts
@@ -73,7 +73,7 @@ export const baseManifest: Omit<ShowStyleBlueprintManifest<ShowStyleConfig>, 'bl
 		endOfShowTimer.setLabel('End of Show')
 
 		// Determine the expected end time from the rundown timing and start a countdown
-		const timing = (context.rundown as Readonly<IBlueprintRundown>).timing
+		const timing = ((context as any)._rundown as Readonly<IBlueprintRundown>).timing
 		let expectedEnd: number | undefined
 		if (timing && timing.type === PlaylistTimingType.BackTime) {
 			expectedEnd = timing.expectedEnd

--- a/packages/blueprints/src/base/showstyle/manifest.ts
+++ b/packages/blueprints/src/base/showstyle/manifest.ts
@@ -70,18 +70,20 @@ export const baseManifest: Omit<ShowStyleBlueprintManifest<ShowStyleConfig>, 'bl
 	/** Called when a RundownPlaylist has been activated */
 	onRundownActivate: async (context: IRundownActivationContext) => {
 		const endOfShowTimer = context.getTimer(1)
-		endOfShowTimer.setLabel('End of Show')
 
 		// Determine the expected end time from the rundown timing and start a countdown
 		const timing = ((context as any)._rundown as Readonly<IBlueprintRundown>).timing
 		let expectedEnd: number | undefined
 		if (timing && timing.type === PlaylistTimingType.BackTime) {
 			expectedEnd = timing.expectedEnd
+			endOfShowTimer.setLabel('End of Show (expected end, backtime)')
 		} else if (timing && timing.type === PlaylistTimingType.ForwardTime) {
 			if (timing.expectedEnd !== undefined) {
 				expectedEnd = timing.expectedEnd
+				endOfShowTimer.setLabel('End of Show (expected end, forward time)')
 			} else if (timing.expectedDuration !== undefined) {
 				expectedEnd = timing.expectedStart + timing.expectedDuration
+				endOfShowTimer.setLabel('End of Show (expected duration, forward time)')
 			}
 		}
 

--- a/packages/blueprints/src/base/showstyle/manifest.ts
+++ b/packages/blueprints/src/base/showstyle/manifest.ts
@@ -17,6 +17,37 @@ import { validateConfig } from './validateConfig.js'
 import { applyConfig } from './applyconfig/index.js'
 import * as ConfigSchema from '../../$schemas/main-showstyle-config.json'
 import { dereferenceSync } from 'dereference-json-schema'
+import type { ITTimersContext, RundownPlaylistTiming } from '@sofie-automation/blueprints-integration'
+
+/**
+ * Initialize or update Timer 2 (End of Show duration timer)
+ * This is called both on activation and during ingest updates
+ */
+function setupTimer2(
+	tTimerContext: ITTimersContext,
+	timing: RundownPlaylistTiming,
+	logDebug: (message: string) => void
+): void {
+	const timer2 = tTimerContext.getTimer(2)
+
+	if (timing?.expectedDuration) {
+		// Check if timer is already initialized
+		if (timer2.mode?.type === 'countdown' && timer2.state) {
+			// Timer exists - update if duration changed
+			const origDuration = timer2.mode.duration
+			if (origDuration !== timing.expectedDuration) {
+				logDebug(`Expected duration changed from ${origDuration} to ${timing.expectedDuration}, updating timer`)
+				timer2.setDuration({ original: timing.expectedDuration })
+			}
+		} else {
+			// Timer doesn't exist - initialize it
+			timer2.setLabel('End of Show (duration)')
+			timer2.startCountdown(timing.expectedDuration, { startPaused: true })
+			timer2.setProjectedAnchorPartByExternalId('end-of-rundown-break')
+			logDebug(`Initialized timer 2 with duration ${timing.expectedDuration}`)
+		}
+	}
+}
 
 export const baseManifest: Omit<ShowStyleBlueprintManifest<ShowStyleConfig>, 'blueprintId' | 'configPresets'> = {
 	/** The type of this blueprint */
@@ -95,12 +126,8 @@ export const baseManifest: Omit<ShowStyleBlueprintManifest<ShowStyleConfig>, 'bl
 			context.logWarning('Expected end time is not defined for this rundown, end of show timer will not be started')
 		}
 
-		if (timing.expectedDuration) {
-			const endOfShowTimer2 = context.getTimer(2)
-			endOfShowTimer2.setLabel('End of Show (duration)')
-			endOfShowTimer2.startCountdown(timing.expectedDuration, { startPaused: true })
-			endOfShowTimer2.setProjectedAnchorPartByExternalId('end-of-rundown-break')
-		}
+		// Initialize or update timer 2 using shared logic
+		setupTimer2(context, timing, (msg) => context.logDebug(msg))
 	},
 	onTake: async (context) => {
 		// Ensure timer 2 is running
@@ -113,17 +140,9 @@ export const baseManifest: Omit<ShowStyleBlueprintManifest<ShowStyleConfig>, 'bl
 		context.getTimer(2).restart()
 	},
 	syncIngestUpdateToPartInstance: (context, _existingPartInstance, _newData, _playoutStatus) => {
-		// Update timer 2 if the expected duration has changed
+		// Initialize or update timer 2 (will create it if it doesn't exist, or update if duration changed)
 		const timing = context.rundown.timing
-		const timer2 = context.getTimer(2)
-
-		if (timing?.expectedDuration && timer2.mode?.type === 'countdown' && timer2.state) {
-			const origDuration = timer2.mode.duration
-			if (origDuration !== timing.expectedDuration) {
-				context.logDebug(`Expected duration changed from ${origDuration} to ${timing.expectedDuration}, updating timer`)
-				timer2.setDuration({ original: timing.expectedDuration })
-			}
-		}
+		setupTimer2(context, timing, (msg) => context.logDebug(msg))
 	},
 	// Uncomment this to enable config fixup migrations between blueprint versions.
 	// Note: When defined, fixUpConfig must be run after every blueprint upload before

--- a/packages/blueprints/src/base/showstyle/manifest.ts
+++ b/packages/blueprints/src/base/showstyle/manifest.ts
@@ -3,7 +3,6 @@ import {
 	ShowStyleBlueprintManifest,
 	JSONBlobStringify,
 	JSONSchema,
-	IBlueprintRundown,
 	IRundownActivationContext,
 	PlaylistTimingType,
 } from '@sofie-automation/blueprints-integration'
@@ -72,7 +71,7 @@ export const baseManifest: Omit<ShowStyleBlueprintManifest<ShowStyleConfig>, 'bl
 		const endOfShowTimer = context.getTimer(1)
 
 		// Determine the expected end time from the rundown timing and start a countdown
-		const timing = ((context as any)._rundown as Readonly<IBlueprintRundown>).timing
+		const timing = context.rundown.timing
 		let expectedEnd: number | undefined
 		if (timing && timing.type === PlaylistTimingType.BackTime) {
 			expectedEnd = timing.expectedEnd

--- a/packages/blueprints/src/base/showstyle/manifest.ts
+++ b/packages/blueprints/src/base/showstyle/manifest.ts
@@ -89,8 +89,8 @@ export const baseManifest: Omit<ShowStyleBlueprintManifest<ShowStyleConfig>, 'bl
 
 		if (expectedEnd !== undefined) {
 			endOfShowTimer.startTimeOfDay(expectedEnd)
-			// Set the anchor part for automatic estimate calculation (over/under diff)
-			endOfShowTimer.setEstimateAnchorPartByExternalId('end-of-rundown-break')
+			// Set the anchor part for automatic projection calculation (over/under diff)
+			endOfShowTimer.setProjectedAnchorPartByExternalId('end-of-rundown-break')
 			context.logDebug(`Expected end time is ${expectedEnd}`)
 		} else {
 			context.logWarning('Expected end time is not defined for this rundown, end of show timer will not be started')
@@ -100,7 +100,7 @@ export const baseManifest: Omit<ShowStyleBlueprintManifest<ShowStyleConfig>, 'bl
 			const endOfShowTimer2 = context.getTimer(2)
 			endOfShowTimer2.setLabel('End of Show (duration)')
 			endOfShowTimer2.startCountdown(timing.expectedDuration, { startPaused: true })
-			endOfShowTimer2.setEstimateAnchorPartByExternalId('end-of-rundown-break')
+			endOfShowTimer2.setProjectedAnchorPartByExternalId('end-of-rundown-break')
 		}
 	},
 	onTake: async (context) => {

--- a/packages/blueprints/src/base/showstyle/manifest.ts
+++ b/packages/blueprints/src/base/showstyle/manifest.ts
@@ -112,6 +112,19 @@ export const baseManifest: Omit<ShowStyleBlueprintManifest<ShowStyleConfig>, 'bl
 		context.getTimer(2).pause()
 		context.getTimer(2).restart()
 	},
+	syncIngestUpdateToPartInstance: (context, _existingPartInstance, _newData, _playoutStatus) => {
+		// Update timer 2 if the expected duration has changed
+		const timing = context.rundown.timing
+		const timer2 = context.getTimer(2)
+
+		if (timing?.expectedDuration && timer2.mode?.type === 'countdown' && timer2.state) {
+			const origDuration = timer2.mode.duration
+			if (origDuration !== timing.expectedDuration) {
+				context.logDebug(`Expected duration changed from ${origDuration} to ${timing.expectedDuration}, updating timer`)
+				timer2.setDuration({ original: timing.expectedDuration })
+			}
+		}
+	},
 	// Uncomment this to enable config fixup migrations between blueprint versions.
 	// Note: When defined, fixUpConfig must be run after every blueprint upload before
 	// config can be validated/applied.

--- a/packages/blueprints/src/base/showstyle/manifest.ts
+++ b/packages/blueprints/src/base/showstyle/manifest.ts
@@ -3,7 +3,9 @@ import {
 	ShowStyleBlueprintManifest,
 	JSONBlobStringify,
 	JSONSchema,
+	IBlueprintRundown,
 	IRundownActivationContext,
+	PlaylistTimingType,
 } from '@sofie-automation/blueprints-integration'
 import { executeAction, executeDataStoreAction } from './executeActions/index.js'
 import { getAdlibItem } from './getAdlibItem.js'
@@ -66,8 +68,27 @@ export const baseManifest: Omit<ShowStyleBlueprintManifest<ShowStyleConfig>, 'bl
 	 */
 	applyConfig,
 	/** Called when a RundownPlaylist has been activated */
-	onRundownActivate: async (_context: IRundownActivationContext) => {
-		// Noop
+	onRundownActivate: async (context: IRundownActivationContext) => {
+		const endOfShowTimer = context.getTimer(1)
+		endOfShowTimer.setLabel('End of Show')
+		endOfShowTimer.setEstimateAnchorPartByExternalId('end-of-rundown-break')
+
+		// Determine the expected end time from the rundown timing and start a countdown
+		const timing = (context.rundown as Readonly<IBlueprintRundown>).timing
+		let expectedEnd: number | undefined
+		if (timing.type === PlaylistTimingType.BackTime) {
+			expectedEnd = timing.expectedEnd
+		} else if (timing.type === PlaylistTimingType.ForwardTime) {
+			if (timing.expectedEnd !== undefined) {
+				expectedEnd = timing.expectedEnd
+			} else if (timing.expectedDuration !== undefined) {
+				expectedEnd = timing.expectedStart + timing.expectedDuration
+			}
+		}
+
+		if (expectedEnd !== undefined) {
+			endOfShowTimer.startTimeOfDay(expectedEnd)
+		}
 	},
 	// Uncomment this to enable config fixup migrations between blueprint versions.
 	// Note: When defined, fixUpConfig must be run after every blueprint upload before

--- a/packages/blueprints/src/base/showstyle/manifest.ts
+++ b/packages/blueprints/src/base/showstyle/manifest.ts
@@ -71,14 +71,13 @@ export const baseManifest: Omit<ShowStyleBlueprintManifest<ShowStyleConfig>, 'bl
 	onRundownActivate: async (context: IRundownActivationContext) => {
 		const endOfShowTimer = context.getTimer(1)
 		endOfShowTimer.setLabel('End of Show')
-		endOfShowTimer.setEstimateAnchorPartByExternalId('end-of-rundown-break')
 
 		// Determine the expected end time from the rundown timing and start a countdown
 		const timing = (context.rundown as Readonly<IBlueprintRundown>).timing
 		let expectedEnd: number | undefined
-		if (timing.type === PlaylistTimingType.BackTime) {
+		if (timing && timing.type === PlaylistTimingType.BackTime) {
 			expectedEnd = timing.expectedEnd
-		} else if (timing.type === PlaylistTimingType.ForwardTime) {
+		} else if (timing && timing.type === PlaylistTimingType.ForwardTime) {
 			if (timing.expectedEnd !== undefined) {
 				expectedEnd = timing.expectedEnd
 			} else if (timing.expectedDuration !== undefined) {
@@ -88,6 +87,11 @@ export const baseManifest: Omit<ShowStyleBlueprintManifest<ShowStyleConfig>, 'bl
 
 		if (expectedEnd !== undefined) {
 			endOfShowTimer.startTimeOfDay(expectedEnd)
+			// Set the anchor part for automatic estimate calculation (over/under diff)
+			endOfShowTimer.setEstimateAnchorPartByExternalId('end-of-rundown-break')
+			context.logDebug(`Expected end time is ${expectedEnd}`)
+		} else {
+			context.logWarning('Expected end time is not defined for this rundown, end of show timer will not be started')
 		}
 	},
 	// Uncomment this to enable config fixup migrations between blueprint versions.

--- a/packages/blueprints/src/base/showstyle/manifest.ts
+++ b/packages/blueprints/src/base/showstyle/manifest.ts
@@ -95,6 +95,17 @@ export const baseManifest: Omit<ShowStyleBlueprintManifest<ShowStyleConfig>, 'bl
 		} else {
 			context.logWarning('Expected end time is not defined for this rundown, end of show timer will not be started')
 		}
+
+		if (timing.expectedDuration) {
+			const endOfShowTimer2 = context.getTimer(2)
+			endOfShowTimer2.setLabel('End of Show (duration)')
+			endOfShowTimer2.startCountdown(timing.expectedDuration, { startPaused: true })
+			endOfShowTimer2.setEstimateAnchorPartByExternalId('end-of-rundown-break')
+		}
+	},
+	onTake: async (context) => {
+		// Ensure timer 2 is running
+		context.getTimer(2).resume()
 	},
 	// Uncomment this to enable config fixup migrations between blueprint versions.
 	// Note: When defined, fixUpConfig must be run after every blueprint upload before

--- a/packages/blueprints/src/base/showstyle/manifest.ts
+++ b/packages/blueprints/src/base/showstyle/manifest.ts
@@ -107,6 +107,12 @@ export const baseManifest: Omit<ShowStyleBlueprintManifest<ShowStyleConfig>, 'bl
 		// Ensure timer 2 is running
 		context.getTimer(2).resume()
 	},
+	onRundownDeActivate: async (context) => {
+		// Stop timers when rundown is deactivated
+		context.getTimer(1).pause()
+		context.getTimer(2).pause()
+		context.getTimer(2).restart()
+	},
 	// Uncomment this to enable config fixup migrations between blueprint versions.
 	// Note: When defined, fixUpConfig must be run after every blueprint upload before
 	// config can be validated/applied.

--- a/packages/blueprints/src/base/showstyle/sofie-editor-parsers/index.ts
+++ b/packages/blueprints/src/base/showstyle/sofie-editor-parsers/index.ts
@@ -84,7 +84,7 @@ export function convertIngestData(context: IRundownUserContext, ingestSegment: S
 			} else if (partPayload.type?.match(/vt|full|package/i)) {
 				parts.push(parseVT(partPayload))
 			} else {
-				parts.push(createInvalidProps(t('Unknown part type'), partPayload))
+				parts.push(createInvalidProps(t('Unknown part type ' + JSON.stringify(partPayload.type)), partPayload))
 			}
 		})
 	} else {

--- a/packages/blueprints/src/base/showstyle/spreadsheet-parsers/index.ts
+++ b/packages/blueprints/src/base/showstyle/spreadsheet-parsers/index.ts
@@ -45,7 +45,7 @@ export function convertIngestData(context: IRundownUserContext, ingestSegment: I
 			} else if (partPayload.type.match(/gfx/i)) {
 				parts.push(parseGfx(partPayload))
 			} else {
-				parts.push(createInvalidProps(t('Unknown part type'), partPayload))
+				parts.push(createInvalidProps(t('Unknown part type ' + JSON.stringify(partPayload.type)), partPayload))
 			}
 		})
 	} else {

--- a/packages/blueprints/src/base/studio/userEditOperations/processIngestData.ts
+++ b/packages/blueprints/src/base/studio/userEditOperations/processIngestData.ts
@@ -73,6 +73,18 @@ export async function processIngestData(
 	} else {
 		context.logWarning(`Unknown change source: ${(ingestChanges as { source: string }).source}`)
 	}
+
+	// Always ensure an end-of-rundown segment exists at the very end, for T-Timer anchoring.
+	// replaceSegment will insert or update, and null positions it last.
+	mutableIngestRundown.replaceSegment(
+		{
+			externalId: 'end-of-rundown',
+			name: 'End of Show',
+			payload: undefined,
+			parts: [],
+		},
+		null
+	)
 }
 
 async function applyIngestOperation(

--- a/packages/blueprints/src/common/context.ts
+++ b/packages/blueprints/src/common/context.ts
@@ -6,6 +6,7 @@ import {
 	IShowStyleContext,
 	ISourceLayer,
 	PackageInfo,
+	Time,
 } from '@sofie-automation/blueprints-integration'
 
 export function isPartContext(context: IShowStyleContext): context is PartContext {
@@ -17,6 +18,7 @@ export class PartContext implements ISegmentUserContext {
 	public readonly studioId: string
 	public readonly rundown: IBlueprintSegmentRundown
 	public readonly playlistId: string
+	public readonly startedPlayback: Time | undefined
 
 	private baseContext: ISegmentUserContext
 	private externalId: string
@@ -31,6 +33,7 @@ export class PartContext implements ISegmentUserContext {
 		this.rundown = baseContext.rundown
 		this.studioId = baseContext.studioId
 		this.playlistId = baseContext.playlistId
+		this.startedPlayback = baseContext.startedPlayback
 	}
 	getShowStyleSourceLayers(): Record<string, ISourceLayer | undefined> {
 		return this.baseContext.getShowStyleSourceLayers()

--- a/yarn.lock
+++ b/yarn.lock
@@ -3969,14 +3969,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sofie-automation/blueprints-integration@npm:26.3.0-nightly-main-20260317-140512-23b7ecc.0":
-  version: 26.3.0-nightly-main-20260317-140512-23b7ecc.0
-  resolution: "@sofie-automation/blueprints-integration@npm:26.3.0-nightly-main-20260317-140512-23b7ecc.0"
+"@sofie-automation/blueprints-integration@npm:26.3.0-nightly-main-20260401-110808-7ef4508.0":
+  version: 26.3.0-nightly-main-20260401-110808-7ef4508.0
+  resolution: "@sofie-automation/blueprints-integration@npm:26.3.0-nightly-main-20260401-110808-7ef4508.0"
   dependencies:
-    "@sofie-automation/shared-lib": "npm:26.3.0-nightly-main-20260317-140512-23b7ecc.0"
+    "@sofie-automation/shared-lib": "npm:26.3.0-nightly-main-20260401-110808-7ef4508.0"
     tslib: "npm:^2.8.1"
     type-fest: "npm:^4.41.0"
-  checksum: 10c0/a28f07166c4abd91d8183d6dca82e3c86f063b2ee425cf60e3d94e99808a7165c8e0d9780f78b0d5326c4f6869d3fb49cac25756c2322a7f56a7b554019705d6
+  checksum: 10c0/5cdeb8ab3a466c2210e8d50fefe28c8e654afa4f18cea14b05785b8726604761f2dabd74d3e67bedae6f50c5b2c9cb887aa408863a5ae4b48439966367a5f6b7
   languageName: node
   linkType: hard
 
@@ -4019,16 +4019,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sofie-automation/shared-lib@npm:26.3.0-nightly-main-20260317-140512-23b7ecc.0":
-  version: 26.3.0-nightly-main-20260317-140512-23b7ecc.0
-  resolution: "@sofie-automation/shared-lib@npm:26.3.0-nightly-main-20260317-140512-23b7ecc.0"
+"@sofie-automation/shared-lib@npm:26.3.0-nightly-main-20260401-110808-7ef4508.0":
+  version: 26.3.0-nightly-main-20260401-110808-7ef4508.0
+  resolution: "@sofie-automation/shared-lib@npm:26.3.0-nightly-main-20260401-110808-7ef4508.0"
   dependencies:
     "@mos-connection/model": "npm:^5.0.0-alpha.0"
     kairos-lib: "npm:^0.2.3"
     timeline-state-resolver-types: "npm:10.0.0-nightly-chore-update-atem-state-20260309-091304-dea89c910.0"
     tslib: "npm:^2.8.1"
     type-fest: "npm:^4.41.0"
-  checksum: 10c0/e29c9bdb6173ef79b83bcc3c4f7887f92abf2f190b1cdbf468a409187d20b6dadb58ce0efb3e0953aa11e805875b673ff3a288fd59fd835403a9bb96184dcd41
+  checksum: 10c0/fce740bf7b433961605d492d96d9ced2e1eed6e72a487b1ce34069da80c2c42a8c12cd044de7fb24e90f0efd066a8d99197adb2a44c07febdf2ecd73adf3e721
   languageName: node
   linkType: hard
 
@@ -5827,7 +5827,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "blueprints@workspace:packages/blueprints"
   dependencies:
-    "@sofie-automation/blueprints-integration": "npm:26.3.0-nightly-main-20260317-140512-23b7ecc.0"
+    "@sofie-automation/blueprints-integration": "npm:26.3.0-nightly-main-20260401-110808-7ef4508.0"
     "@types/node": "npm:^22.19.3"
     dereference-json-schema: "npm:^0.2.1"
     sofie-blueprint-tools: "npm:^1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3969,14 +3969,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sofie-automation/blueprints-integration@npm:26.3.0-nightly-main-20260401-110808-7ef4508.0":
-  version: 26.3.0-nightly-main-20260401-110808-7ef4508.0
-  resolution: "@sofie-automation/blueprints-integration@npm:26.3.0-nightly-main-20260401-110808-7ef4508.0"
+"@sofie-automation/blueprints-integration@npm:26.3.0-nightly-main-20260421-093052-38fae25.0":
+  version: 26.3.0-nightly-main-20260421-093052-38fae25.0
+  resolution: "@sofie-automation/blueprints-integration@npm:26.3.0-nightly-main-20260421-093052-38fae25.0"
   dependencies:
-    "@sofie-automation/shared-lib": "npm:26.3.0-nightly-main-20260401-110808-7ef4508.0"
+    "@sofie-automation/shared-lib": "npm:26.3.0-nightly-main-20260421-093052-38fae25.0"
     tslib: "npm:^2.8.1"
     type-fest: "npm:^4.41.0"
-  checksum: 10c0/5cdeb8ab3a466c2210e8d50fefe28c8e654afa4f18cea14b05785b8726604761f2dabd74d3e67bedae6f50c5b2c9cb887aa408863a5ae4b48439966367a5f6b7
+  checksum: 10c0/26c98cd4ca9eda22d8657e56dfcb10578b9b7f114dca788475e03728fc87a60058a21f47b5d6aa6b7934b203a14c59ccf0b7faf1a11820dc03545e82b6c2f50d
   languageName: node
   linkType: hard
 
@@ -4019,16 +4019,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sofie-automation/shared-lib@npm:26.3.0-nightly-main-20260401-110808-7ef4508.0":
-  version: 26.3.0-nightly-main-20260401-110808-7ef4508.0
-  resolution: "@sofie-automation/shared-lib@npm:26.3.0-nightly-main-20260401-110808-7ef4508.0"
+"@sofie-automation/shared-lib@npm:26.3.0-nightly-main-20260421-093052-38fae25.0":
+  version: 26.3.0-nightly-main-20260421-093052-38fae25.0
+  resolution: "@sofie-automation/shared-lib@npm:26.3.0-nightly-main-20260421-093052-38fae25.0"
   dependencies:
     "@mos-connection/model": "npm:^5.0.0-alpha.0"
-    kairos-lib: "npm:^0.2.3"
-    timeline-state-resolver-types: "npm:10.0.0-nightly-chore-update-atem-state-20260309-091304-dea89c910.0"
+    kairos-lib: "npm:^1.0.0"
+    timeline-state-resolver-types: "npm:10.0.0-nightly-main-20260415-093148-f35c4cadc.0"
     tslib: "npm:^2.8.1"
     type-fest: "npm:^4.41.0"
-  checksum: 10c0/fce740bf7b433961605d492d96d9ced2e1eed6e72a487b1ce34069da80c2c42a8c12cd044de7fb24e90f0efd066a8d99197adb2a44c07febdf2ecd73adf3e721
+  checksum: 10c0/e266d96a9845ea0fbb9d7e6dd3b1c8ac56963a4e8d15b4310c845cf5b743350ce76e58e2ae45e094810983211c9982ff471621f33bb8c901d79a7fad782948e7
   languageName: node
   linkType: hard
 
@@ -5827,7 +5827,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "blueprints@workspace:packages/blueprints"
   dependencies:
-    "@sofie-automation/blueprints-integration": "npm:26.3.0-nightly-main-20260401-110808-7ef4508.0"
+    "@sofie-automation/blueprints-integration": "npm:26.3.0-nightly-main-20260421-093052-38fae25.0"
     "@types/node": "npm:^22.19.3"
     dereference-json-schema: "npm:^0.2.1"
     sofie-blueprint-tools: "npm:^1.3.0"
@@ -10999,12 +10999,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"kairos-lib@npm:0.2.3, kairos-lib@npm:^0.2.3":
-  version: 0.2.3
-  resolution: "kairos-lib@npm:0.2.3"
+"kairos-lib@npm:1.0.0, kairos-lib@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "kairos-lib@npm:1.0.0"
   dependencies:
     tslib: "npm:^2.8.1"
-  checksum: 10c0/d40347cc5f3b00a10acee99156b54e2fe742dc5d80def3749f5096b2c8da5b03491c7ac87172421684846debb13cbc4f1f2a3283debb6b95b3d7b94e64514db1
+  checksum: 10c0/d1290f1611ad2d73482eeae3ad1d760ad88d92a1d91abd33344ef8eb5db034096c36cc52cbeb1152322993f9014ac5cb13b8110ed23dd7b36080dcd55b78caaf
   languageName: node
   linkType: hard
 
@@ -16571,13 +16571,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"timeline-state-resolver-types@npm:10.0.0-nightly-chore-update-atem-state-20260309-091304-dea89c910.0":
-  version: 10.0.0-nightly-chore-update-atem-state-20260309-091304-dea89c910.0
-  resolution: "timeline-state-resolver-types@npm:10.0.0-nightly-chore-update-atem-state-20260309-091304-dea89c910.0"
+"timeline-state-resolver-types@npm:10.0.0-nightly-main-20260415-093148-f35c4cadc.0":
+  version: 10.0.0-nightly-main-20260415-093148-f35c4cadc.0
+  resolution: "timeline-state-resolver-types@npm:10.0.0-nightly-main-20260415-093148-f35c4cadc.0"
   dependencies:
-    kairos-lib: "npm:0.2.3"
+    kairos-lib: "npm:1.0.0"
     tslib: "npm:^2.8.1"
-  checksum: 10c0/45059ee998e8c90301363be61d9533ef635e56c2df02232ead0deb2c7987de44400260f6099605e1326d625946d1e7c257609db8a7ffba6f78d5f59a4662186d
+  checksum: 10c0/4efd55ce4d0eb761200c6181a7ee4e1818219e66fb5141e3a9be353a4e5437d39bb5e4febf4ad19cb5100506fb1013449a819cc327903e144332352b417ea553
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add a T-Timer that counts to the scheduled end of the show based on the absolute time it is scheduled to end and another that counts based on the scheduled duration added to the time of the first take.

These can be compared to the built in timing to test the T-Timer's calculations are correct. In practise they wouldn't count to the end of the show, they would count to some other break point, but this is for PoC / testing.