### PR TITLE
feat: add deviceActionMessages examples for HTTP Send action errors

### DIFF
--- a/packages/blueprints/src/base/studio/manifest.ts
+++ b/packages/blueprints/src/base/studio/manifest.ts
@@ -14,7 +14,7 @@ import * as ConfigSchema from '../../$schemas/main-studio-config.json'
 import { StudioConfig } from './helpers/config.js'
 import { processIngestData } from './userEditOperations/processIngestData.js'
 import { dereferenceSync } from 'dereference-json-schema'
-import { AtemStatusCode, CasparCGStatusCode } from 'timeline-state-resolver-types'
+import { AtemStatusCode, CasparCGStatusCode, HttpSendActionErrorCode } from 'timeline-state-resolver-types'
 
 export const baseManifest: Omit<StudioBlueprintManifest<StudioConfig>, 'blueprintId' | 'configPresets'> = {
 	blueprintType: BlueprintManifestType.STUDIO,
@@ -48,6 +48,15 @@ export const baseManifest: Omit<StudioBlueprintManifest<StudioConfig>, 'blueprin
 		[AtemStatusCode.DISCONNECTED]: '🎬 Vision mixer {{deviceName}} ran away! 🏃‍♂️💨 (Check the ATEM connection)',
 		[AtemStatusCode.PSU_FAULT]: '⚡ {{deviceName}}: Power supply {{psuNumber}} is faulty - check hardware',
 		[CasparCGStatusCode.QUEUE_OVERFLOW]: '{{deviceName}} needs restart - CasparCG command queue is full',
+	},
+
+	// Device action error message customization - overrides default messages when TSR device actions fail
+	deviceActionMessages: {
+		// Network failure: show the URL so operators know which endpoint is unreachable
+		[HttpSendActionErrorCode.REQUEST_FAILED]: 'HTTP action failed - could not reach {{url}}: {{errorMessage}}',
+		// Config errors: friendlier messages than the raw TSR defaults
+		[HttpSendActionErrorCode.MISSING_URL]: 'HTTP action not configured - no URL set in the timeline object',
+		[HttpSendActionErrorCode.INVALID_TYPE]: 'HTTP action has invalid method "{{type}}" - check blueprint config',
 	},
 }
 


### PR DESCRIPTION
## About the Contributor

This pull request is posted on behalf of the BBC.

## Type of Contribution

Feature / Documentation

## Current Behavior

The demo blueprints demonstrate device status message customisation (PR #99) but don't show how to customise action error messages.

## New Behavior

The studio manifest now includes `deviceActionMessages` with example overrides for three `HttpSendActionErrorCode` codes, showing blueprint authors how to customise action failure messages with context interpolation:

```typescript
deviceActionMessages: {
  [HttpSendActionErrorCode.REQUEST_FAILED]: 'HTTP action failed - could not reach {{url}}: {{errorMessage}}',
  [HttpSendActionErrorCode.MISSING_URL]: 'HTTP action not configured - no URL set in the timeline object',
  [HttpSendActionErrorCode.INVALID_TYPE]: 'HTTP action has invalid method "{{type}}" - check blueprint config',
}
```

Stacked on PR #99 (`feat: Status message customisation`).

## Testing Instructions

Build the demo blueprints and verify the studio manifest compiles cleanly with the new `deviceActionMessages` field.

## Status

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
